### PR TITLE
Architecture/kiosk interface

### DIFF
--- a/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
@@ -137,24 +137,24 @@ abstract class IKiosk {
                     design()
                 }
 
-                var descBoxModifier: Modifier? = GetTutorialDescriptionModifier[GetCounter()]
-                if (descBoxModifier == null) descBoxModifier =
-                    GetTutorialDescriptionDefaultModifier()
+                var descBoxModifier: Modifier = GetTutorialDescriptionModifier[GetCounter()] ?: Modifier
 
                 Box(
                     modifier = Modifier
                         .fillMaxSize(),
                     contentAlignment = Alignment.BottomCenter
                 ) {
+                    val background = 0xAF000000 or 0x000000
+
                     Column(
                         modifier = Modifier
-                            .background(Color(0xAF_FFFFFF)),
+                            .background(Color(background)),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Bottom
 
                     ) {
                         Box(
-                            modifier = descBoxModifier,
+                            modifier = GetTutorialDescriptionDefaultModifier().composed{descBoxModifier},
                             contentAlignment = Alignment.Center
                         ) {
                             if (GetCounter() < GetTutorialDescription.count()) {

--- a/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
@@ -3,126 +3,205 @@ package com.example.kiosktutorial.Screen
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import java.util.*
+import kotlin.collections.ArrayList
 
 abstract class IKiosk {
-    constructor(isTutorial:Boolean){
+    constructor(isTutorial: Boolean) {
         setIsTutorial(isTutorial)
         _step = 0
 
     }
 
-    protected var _isTutorial:Boolean = false
-    protected fun setIsTutorial(value:Boolean){
+    protected var _isTutorial: Boolean = false
+    protected fun setIsTutorial(value: Boolean) {
         this._isTutorial = value
     }
+
     protected fun IsTutorial() = _isTutorial
 
 
     // this variable will inc/dec when next/prev step in tutorial mode
+    private val STEP_MIN = 0
+    protected open val STEP_MAX = 300
+
     protected var _step by mutableStateOf(-1)
     protected fun GetCounter() = _step
-    protected fun IncStep(){
-        _step = _step + 1
+    protected fun IncStep() {
+        if (GetCounter() < STEP_MAX) _step++
     }
 
-    fun Modifier.SetMode(step:Int,
-                         defaultModifier:Modifier = Modifier,
-                         tutorialModifier:Modifier = Modifier,
-                         additionalModifier:Modifier? = null,
-                         function:()->Unit
-    ):Modifier{
-        if(!IsTutorial()){
+    private fun DecStep() {
+        if (STEP_MIN < GetCounter()) _step--
+    }
+
+    fun Modifier.SetMode(
+        step: Int,
+        defaultModifier: Modifier = Modifier,
+        additionalModifier: Modifier = Modifier,
+        overrideModifier: Modifier? = null,
+        function: () -> Unit
+    ): Modifier {
+        // if tutorial mode?
+        if (!IsTutorial()) {
+            // not
             return this
-                .composed{defaultModifier}
-                .clickable{
+                .composed { defaultModifier }
+                .clickable {
                     function()
                 }
-        }
-        else{
-            if(step == GetCounter()){
-                if(additionalModifier != null){
+        } else {
+            // yes
+            // is current step are correct sequence?
+            if (step == GetCounter()) {
+                // yes
+                // is modifier override mode?
+                if (overrideModifier != null) {
+                    //yes
                     return this
-                        .composed{defaultModifier}
-                        .composed{additionalModifier}
-                        .clickable{
+                        .composed { overrideModifier }
+                        .clickable {
                             function()
                             IncStep()
                         }
                 }
+                // no
                 return this
-                    .composed{tutorialModifier}
-                    .clickable{
+                    .composed { defaultModifier }
+                    .composed { additionalModifier }
+                    .clickable {
                         function()
                         IncStep()
                     }
             }
+            // no
             return this
-                .composed{
+                .composed {
                     defaultModifier
                 }
         }
     }
 
     @Deprecated("plz use Modifier.SetMode Instead of this function")
-    fun Modifier.SetTutorialMode(step:Int,
-                                 mod:Modifier = Modifier,
-                                 func:()->Unit):Modifier{
-        if(IsTutorial() && GetCounter() == step){
-            return this.composed{mod}
-                .clickable{
-                func()
-                IncStep()
-            }
+    fun Modifier.SetTutorialMode(
+        step: Int,
+        mod: Modifier = Modifier,
+        func: () -> Unit
+    ): Modifier {
+        if (IsTutorial() && GetCounter() == step) {
+            return this
+                .composed { mod }
+                .clickable {
+                    func()
+                    IncStep()
+                }
         }
         return this
     }
 
     @Deprecated("plz use Modifier.SetMode Instead of this function")
-    fun Modifier.SetRealMode(mod:Modifier = Modifier, func:()->Unit):Modifier{
-        if(!IsTutorial()){
-            return this.composed{mod}
-                .clickable{
-                func()
-            }
+    fun Modifier.SetRealMode(mod: Modifier = Modifier, func: () -> Unit): Modifier {
+        if (!IsTutorial()) {
+            return this
+                .composed { mod }
+                .clickable {
+                    func()
+                }
         }
         return this
     }
 
     @Composable
-    open fun Layout(design:@Composable()()->Unit){
-        if(IsTutorial()){
-            Column(
+    open fun Layout(design: @Composable() () -> Unit) {
+        if (IsTutorial()) {
+            Box(
                 modifier = Modifier
                     .fillMaxHeight()
-            ){
+            ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .fillMaxHeight(0.75f)
-                ){
+                ) {
                     design()
                 }
+
+                var descBoxModifier: Modifier? = GetTutorialDescriptionModifier[GetCounter()]
+                if (descBoxModifier == null) descBoxModifier =
+                    GetTutorialDescriptionDefaultModifier()
+
                 Box(
                     modifier = Modifier
-                        .background(Color(0xFF888888))
-                        .fillMaxWidth()
-                        .fillMaxHeight(1f)
-                ){
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.BottomCenter
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .background(Color(0xAF_FFFFFF)),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Bottom
 
+                    ) {
+                        Box(
+                            modifier = descBoxModifier,
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (GetCounter() < GetTutorialDescription.count()) {
+                                Text(text = GetTutorialDescription[GetCounter()])
+                            }
+                        }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 40.dp)
+                        ) {
+                            Button(
+                                modifier = Modifier
+                                    .fillMaxWidth(0.5f)
+                                    .fillMaxHeight(),
+                                enabled = STEP_MIN < GetCounter(),
+                                onClick = {
+                                    DecStep()
+                                }) {
+                                Text(text = "이전")
+                            }
+                            Button(
+                                modifier = Modifier
+                                    .fillMaxWidth(1f)
+                                    .fillMaxHeight(),
+                                enabled = GetCounter() < STEP_MAX,
+                                onClick = {
+                                    IncStep()
+                                }) {
+                                Text(text = "다음")
+                            }
+                        }
+                    }
                 }
             }
-        }else{
+        } else {
             design()
         }
     }
 
-    protected abstract fun GetTutorialDescrption():ArrayList<String>
+    protected abstract var GetTutorialDescription: ArrayList<String>
+    protected abstract var GetTutorialDescriptionModifier: MutableMap<Int, Modifier>
+
+    protected open fun GetTutorialDescriptionDefaultModifier() = Modifier
+        .fillMaxWidth()
+        .padding(10.dp)
+
 
 }

--- a/app/src/main/java/com/example/kiosktutorial/Screen/Kiosk/KioskTest.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/Kiosk/KioskTest.kt
@@ -51,14 +51,14 @@ class KioskTest(isTutorial: Boolean) : IKiosk(isTutorial) {
             modifier = Modifier.fillMaxSize()
         ) {
             Text(
-                text = "${GetCounter()} 번째 / 튜토리얼 모드 ${if(!IsTutorial()) "아님" else ""}"
+                text = "${getCounter()} 번째 / 튜토리얼 모드 ${if(!isTutorial()) "아님" else ""}"
             )
             Box(
                 modifier = Modifier
                     .border(1.dp, Color(0xff000000))
                     .widthIn(20.dp)
                     .heightIn(80.dp)
-                    .SetMode(
+                    .setMode(
                         1,
                         defaultModifier = Modifier
                             .background(Color(0xffff00ff)),
@@ -69,7 +69,7 @@ class KioskTest(isTutorial: Boolean) : IKiosk(isTutorial) {
             ) {
                 Text(text ="클릭하면 시작합니다.",
                     modifier = Modifier
-                        .SetMode(0){
+                        .setMode(0){
                         }
                 )
             }

--- a/app/src/main/java/com/example/kiosktutorial/Screen/Kiosk/KioskTest.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/Kiosk/KioskTest.kt
@@ -6,23 +6,42 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.kiosktutorial.Screen.IKiosk
+import com.example.kiosktutorial.Screen.TutorialStepData
 
 class KioskTest(isTutorial: Boolean) : IKiosk(isTutorial) {
 
-    override var GetTutorialDescription = arrayListOf<String>(
-        "테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 "
-    )
-
-    override var GetTutorialDescriptionModifier = mutableMapOf<Int, Modifier>(
-        1 to Modifier.fillMaxWidth()
-    )
-
+    override var tutorialStepDataList: Map<Int, TutorialStepData> =
+        mutableMapOf(
+            1 to TutorialStepData("hello world"),
+            2 to TutorialStepData("this is second step"),
+            3 to TutorialStepData(
+                "third step is applied custom modifier that change padding and make border",
+                boxModifier = Modifier
+                    .padding(15.dp)
+                    .border(width = 2.dp, color = Color(0xFFFFFFFF))
+                    .padding(10.dp, 5.dp),
+                background = 0xFF000000 or 0x045526
+            ),
+            4 to TutorialStepData(
+                description = "this text will be ignored",
+                background = 0xFF000000 or 0xffe65a,
+                overrideText = {
+                    Text(
+                        text = "4th step is introduce override inner Text component. if this parameter is not null, description string will be ignored."
+                    )
+                }),
+            5 to TutorialStepData(
+                description = "description area can setting top of screen",
+                alignment = Alignment.TopCenter
+            )
+        )
 
     @Composable
     fun MainAct() {
@@ -46,17 +65,11 @@ class KioskTest(isTutorial: Boolean) : IKiosk(isTutorial) {
                         overrideModifier = Modifier
                             .background(Color(0xff00ff00))
                     ) {
-                        toast?.cancel()
-                        toast = Toast.makeText(context, "${GetCounter()}번입니다", Toast.LENGTH_SHORT)
-                        toast!!.show()
                     }
             ) {
                 Text(text ="클릭하면 시작합니다.",
                     modifier = Modifier
                         .SetMode(0){
-                            toast?.cancel()
-                            toast = Toast.makeText(context, "Hello start with you play $_step", Toast.LENGTH_SHORT)
-                            toast!!.show()
                         }
                 )
             }

--- a/app/src/main/java/com/example/kiosktutorial/Screen/Kiosk/KioskTest.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/Kiosk/KioskTest.kt
@@ -15,9 +15,14 @@ import com.example.kiosktutorial.Screen.IKiosk
 
 class KioskTest(isTutorial: Boolean) : IKiosk(isTutorial) {
 
-    override fun GetTutorialDescrption() = arrayListOf<String>(
-        "st"
+    override var GetTutorialDescription = arrayListOf<String>(
+        "테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 테스트1 테스트2 "
     )
+
+    override var GetTutorialDescriptionModifier = mutableMapOf<Int, Modifier>(
+        1 to Modifier.fillMaxWidth()
+    )
+
 
     @Composable
     fun MainAct() {
@@ -38,7 +43,7 @@ class KioskTest(isTutorial: Boolean) : IKiosk(isTutorial) {
                         1,
                         defaultModifier = Modifier
                             .background(Color(0xffff00ff)),
-                        tutorialModifier = Modifier
+                        overrideModifier = Modifier
                             .background(Color(0xff00ff00))
                     ) {
                         toast?.cancel()

--- a/app/src/main/java/com/example/kiosktutorial/Screen/layout.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/layout.kt
@@ -1,8 +1,6 @@
 package com.example.kiosktutorial.Screen
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.CornerSize
@@ -27,6 +25,7 @@ import com.example.kiosktutorial.ui.theme.backGround
 @Composable
 fun ActMainContent( innerContent:@Composable() ()->Unit){
     val cornerRounded = CornerSize(25.dp)
+    val vScrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .background(
@@ -37,6 +36,7 @@ fun ActMainContent( innerContent:@Composable() ()->Unit){
                     bottomEnd = CornerSize(0.dp)
                 ), color = Color.White
             )
+            .verticalScroll(vScrollState)
             .padding(10.dp)
             .fillMaxSize()
     ){

--- a/app/src/main/java/com/example/kiosktutorial/Screen/mainHome.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/mainHome.kt
@@ -70,10 +70,16 @@ fun Home(navHostController: NavHostController) {
                 navHostController.navigate(Screen.GameHome.route)
             }
 //            MovButton(
-//                title = "Test",
+//                title = "Test - tutorial",
 //                icon = R.drawable.game
 //            ) {
-//                navHostController.navigate("1234test")
+//                navHostController.navigate("kioskTestTutorial")
+//            }
+//            MovButton(
+//                title = "Test - real",
+//                icon = R.drawable.game
+//            ) {
+//                navHostController.navigate("kioskTestReal")
 //            }
 
         }

--- a/app/src/main/java/com/example/kiosktutorial/Screen/navGraph.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/navGraph.kt
@@ -5,9 +5,12 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import com.example.kiosktutorial.R
 import com.example.kiosktutorial.Screen.Kiosk.*
 import kotlinx.coroutines.delay
@@ -74,13 +77,14 @@ fun SetupNavGraph(navController: NavHostController) {
             view.View()
         }
 
-        lateinit var test: KioskTest
-        composable(route = "1234test"){
-            test = KioskTest(true)
-            test.Layout{
-                test.MainAct()
-            }
-        }
+//        lateinit var test: KioskTest
+//        composable(route = "1234test"){
+//            test = KioskTest(true)
+//            test.Layout{
+//                test.MainAct()
+//            }
+//        }
+        setupKioskTest(navController)
 
         composable(route = Screen.KioskExerciseSelection.route) {
             SecondHome(navController, true)
@@ -207,5 +211,25 @@ fun SetupNavGraph(navController: NavHostController) {
             HospitalCheck(navController, hvModel)
         }
 
+    }
+
+
+}
+
+fun NavGraphBuilder.setupKioskTest(navController: NavController){
+    navigation(startDestination = "kioskTestTutorial", route = "kioskTest"){
+        val tutorial = KioskTest(true)
+        val real = KioskTest(false)
+        composable(route = "kioskTestTutorial"){
+            tutorial.Layout{
+                tutorial.MainAct()
+            }
+        }
+
+        composable(route = "kioskTestReal"){
+            real.Layout{
+                real.MainAct()
+            }
+        }
     }
 }


### PR DESCRIPTION
- tutorial mode의 설명 영역 ux 개선
    - 상하단 컴포넌트 적용 시 설명 영역 align 설정
- `IKiosk` 클래스 사용에 대한 예제 시안 추가

tutorial mode
![image](https://user-images.githubusercontent.com/40613626/236149802-2224e35b-f32f-4f76-bac8-33cecb2ee575.png)
