### PR TITLE
Fix/IKiosk - layout

### DIFF
--- a/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
@@ -98,12 +98,11 @@ abstract class IKiosk {
         if (isTutorial()) {
             Box(
                 modifier = Modifier
-                    .fillMaxHeight()
+                    .fillMaxSize()
             ) {
                 Box(    // content
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .fillMaxHeight(0.75f)
+                        .fillMaxSize()
                 ) {
                     design()
                 }
@@ -119,6 +118,7 @@ abstract class IKiosk {
 
                     Column(
                         modifier = Modifier
+                            .clickable(false){}
                             .background(Color(tutorialStepData?.GetBackground() ?: defaultTutorialStepData.GetBackground())),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Bottom


### PR DESCRIPTION
this PR is only changed description area design of tutorial mode.  
usage method was not changed

change list
- content will filled all screen(before:only filled 75% of screen height)
- description area no longer clickable