### PR TITLE
Hotfix/ikiosk/tutorial step procedure fix

### DIFF
--- a/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
@@ -69,9 +69,9 @@ abstract class IKiosk {
                     return this
                         .composed { overrideModifier }
                         .clickable {
-                            function()
                             if(stepIncState())
                                 incStep()
+                            function()
                         }
                 }
                 // no
@@ -79,9 +79,9 @@ abstract class IKiosk {
                     .composed { defaultModifier }
                     .composed { additionalModifier }
                     .clickable {
-                        function()
                         if(stepIncState())
                             incStep()
+                        function()
                     }
             }
             // no

--- a/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
+++ b/app/src/main/java/com/example/kiosktutorial/Screen/IKiosk.kt
@@ -1,5 +1,6 @@
 package com.example.kiosktutorial.Screen
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -35,6 +36,23 @@ abstract class IKiosk {
 
     private var _step by mutableStateOf(-1)
     internal fun getCounter() = _step
+
+    /**
+     * if `isForceModifyingStep value is true, you can use function `forceModifyingStep`
+     */
+    protected var isForceModifyingStep = false
+    /**
+     * `step` value force change function. only you can use when var `isForceModifyingStep` has true.
+     *  if that var value has false, you can't use this function.
+     *  if you use this function when var value isn't true, it occurs runtime error.
+      */
+    internal fun forceModifyingStep(to:Int){
+        if(!isForceModifyingStep) {
+            Log.d("change isForceModifyingStep value to true", "you can't use forceModifyingStep function. if you want use this function, change isForceModifyingStep value to true")
+            throw Exception("you doesn't make forceModifyingStep to true. if you want use this function, change isForceModifyingStep value to true")
+        }
+        else _step = to
+    }
     private fun incStep() {
         if (getCounter() < STEP_MAX) _step++
     }


### PR DESCRIPTION
TutorialStepData의 `stateFunction`과 ext function인 `setMode`에서 IKiosk의 step 값이 변경되는 순서가 다른 문제를 발견했습니다.  
또한, 일부 경우에서 강제로 step 값의 수정이 필요한 부분이 있을 것이라 판단하여, 특정 변수의 값을 `true`로 변경한 후에 한해 강제 step 값 변경이 가능한 함수를 추가하였습니다.

변경된 내용
---
- step 증감 방식 단일화
- step값 강제 변경 함수 추가.
  #41